### PR TITLE
Add docstrings to component methods

### DIFF
--- a/src/components/combobox.py
+++ b/src/components/combobox.py
@@ -13,7 +13,33 @@ class ComboBox(BaseComponent):
     """
     A wrapper for dcc.Dropdown styled as a ComboBox, integrated with the theme system.
     """
-    def __init__(self, id, options=None, value=None, placeholder=None, theme=None, style=None, clearable=True, searchable=True, multi=False, className=""):
+    def __init__(
+        self,
+        id,
+        options=None,
+        value=None,
+        placeholder=None,
+        theme=None,
+        style=None,
+        clearable=True,
+        searchable=True,
+        multi=False,
+        className="",
+    ):
+        """Instantiate a ComboBox component.
+
+        Args:
+            id: The unique component identifier.
+            options: List of option dicts or strings to populate the dropdown.
+            value: Currently selected value(s).
+            placeholder: Placeholder text when no value is selected.
+            theme: Optional theme configuration for styling.
+            style: Custom CSS style overrides.
+            clearable: Whether the selection can be cleared by the user.
+            searchable: Whether the dropdown includes a search box.
+            multi: Enable multi-select mode if ``True``.
+            className: Additional CSS class names for the wrapper.
+        """
         super().__init__(id, theme)
         self.options = options if options is not None else []
         self.value = value
@@ -29,6 +55,11 @@ class ComboBox(BaseComponent):
 
 
     def render(self):
+        """Render the ComboBox as a Dash ``dcc.Dropdown`` component.
+
+        Returns:
+            dcc.Dropdown: The Dash dropdown element with merged theme styles.
+        """
         # Get default styles using the correct function from colour_palette
         default_style = get_combobox_default_style(self.theme)
 

--- a/src/components/container.py
+++ b/src/components/container.py
@@ -11,7 +11,25 @@ class Container(BaseComponent):
     A wrapper for dbc.Container that allows for easier styling and theme integration.
     It can accept other BaseComponent instances as children and will render them.
     """
-    def __init__(self, id, children=None, theme=None, style=None, fluid=False, className=""):
+    def __init__(
+        self,
+        id,
+        children=None,
+        theme=None,
+        style=None,
+        fluid=False,
+        className="",
+    ):
+        """Instantiate a Container component.
+
+        Args:
+            id: The unique component identifier.
+            children: Child components or layouts contained within the container.
+            theme: Optional theme configuration for styling.
+            style: Custom CSS style overrides.
+            fluid: Enable full-width container behavior.
+            className: Additional CSS classes for the container.
+        """
         super().__init__(id, theme)
         self.children = children if children is not None else []
         self.style = style if style is not None else {}
@@ -19,6 +37,11 @@ class Container(BaseComponent):
         self.className = className
 
     def render(self):
+        """Render the container and its children as a ``dbc.Container``.
+
+        Returns:
+            dbc.Container: The rendered Dash Bootstrap container with children.
+        """
         # Get default styles from utility function
         default_style = get_container_default_style(self.theme)
         

--- a/src/components/graph.py
+++ b/src/components/graph.py
@@ -12,7 +12,25 @@ class Graph(BaseComponent):
     """
     A wrapper for dcc.Graph with theme integration for layout.
     """
-    def __init__(self, id, figure=None, theme=None, style=None, config=None, className=""):
+    def __init__(
+        self,
+        id,
+        figure=None,
+        theme=None,
+        style=None,
+        config=None,
+        className="",
+    ):
+        """Instantiate a Graph component with optional theming.
+
+        Args:
+            id: The unique component identifier.
+            figure: A Plotly figure object to display.
+            theme: Optional theme configuration for styling.
+            style: CSS style overrides for the wrapper.
+            config: Additional Plotly configuration options.
+            className: Additional CSS class names for the wrapper.
+        """
         super().__init__(id, theme)
         self.figure = figure if figure is not None else go.Figure()
         self.style = style if style is not None else {'height': '400px'} # Default height
@@ -30,6 +48,11 @@ class Graph(BaseComponent):
             self.figure.update_layout(**default_layout)
 
     def render(self):
+        """Render the graph as a Dash ``dcc.Graph`` component.
+
+        Returns:
+            dcc.Graph: The graph component with themed layout and styles.
+        """
         # Ensure theme is applied before rendering
         self._apply_theme_to_figure()
 

--- a/src/components/listbox.py
+++ b/src/components/listbox.py
@@ -12,7 +12,27 @@ class ListBox(BaseComponent):
     """
     A wrapper for dcc.Dropdown styled as a ListBox (multi-select often implied).
     """
-    def __init__(self, id, options=None, value=None, theme=None, style=None, multi=True, className=""):
+    def __init__(
+        self,
+        id,
+        options=None,
+        value=None,
+        theme=None,
+        style=None,
+        multi=True,
+        className="",
+    ):
+        """Instantiate a ListBox component.
+
+        Args:
+            id: The unique component identifier.
+            options: List of option dicts or strings.
+            value: The selected value list for multi-select.
+            theme: Optional theme configuration for styling.
+            style: Custom CSS style overrides.
+            multi: Allow multiple selections if ``True``.
+            className: Additional CSS classes for the wrapper.
+        """
         super().__init__(id, theme)
         self.options = options if options is not None else []
         self.value = value if value is not None else [] # Default to empty list for multi
@@ -24,6 +44,11 @@ class ListBox(BaseComponent):
              self.options = [{'label': opt, 'value': opt} for opt in self.options]
 
     def render(self):
+        """Render the ListBox as a Dash ``dcc.Dropdown`` component.
+
+        Returns:
+            dcc.Dropdown: The configured dropdown with list box styling.
+        """
         # Get default styles using the correct function from colour_palette
         # This function returns a dict containing potentially 'style', 'inputStyle', 'labelStyle'
         default_styles_dict = get_listbox_default_styles(self.theme)

--- a/src/components/radiobutton.py
+++ b/src/components/radiobutton.py
@@ -12,7 +12,31 @@ class RadioButton(BaseComponent):
     """
     A wrapper for dcc.RadioItems with theme integration.
     """
-    def __init__(self, id, options=None, value=None, theme=None, style=None, inline=False, labelStyle=None, inputStyle=None, className=""):
+    def __init__(
+        self,
+        id,
+        options=None,
+        value=None,
+        theme=None,
+        style=None,
+        inline=False,
+        labelStyle=None,
+        inputStyle=None,
+        className="",
+    ):
+        """Instantiate a RadioButton component.
+
+        Args:
+            id: The unique component identifier.
+            options: List of options as dicts or strings.
+            value: Currently selected value.
+            theme: Optional theme configuration for styling.
+            style: CSS styles for the outer container.
+            inline: Display radio items inline when ``True``.
+            labelStyle: Style overrides for the label elements.
+            inputStyle: Style overrides for the input elements.
+            className: Additional CSS classes for the wrapper.
+        """
         super().__init__(id, theme)
         self.options = options if options is not None else []
         self.value = value
@@ -26,6 +50,11 @@ class RadioButton(BaseComponent):
              self.options = [{'label': opt, 'value': opt} for opt in self.options]
 
     def render(self):
+        """Render the radio buttons as a Dash ``dcc.RadioItems`` component.
+
+        Returns:
+            dcc.RadioItems: The configured set of radio buttons.
+        """
         # Get default styles from the centralized styling function
         default_styles = get_radiobutton_default_styles(self.theme)
         

--- a/src/components/tabs.py
+++ b/src/components/tabs.py
@@ -15,7 +15,25 @@ class Tabs(BaseComponent):
     Expects 'tabs' prop to be a list of tuples: [('Tab Label 1', content1), ('Tab Label 2', content2)]
     Content can be a BaseComponent instance or any Dash-compatible component layout.
     """
-    def __init__(self, id, tabs=None, active_tab=None, theme=None, style=None, className=""):
+    def __init__(
+        self,
+        id,
+        tabs=None,
+        active_tab=None,
+        theme=None,
+        style=None,
+        className="",
+    ):
+        """Instantiate a Tabs component.
+
+        Args:
+            id: The unique component identifier.
+            tabs: List of ``(label, content)`` tuples defining each tab.
+            active_tab: Identifier of the tab that should be active initially.
+            theme: Optional theme configuration for styling.
+            style: CSS style overrides for the tabs container.
+            className: Additional CSS class names for the wrapper.
+        """
         super().__init__(id, theme)
         self.tabs_data = tabs if tabs is not None else []
         self.active_tab = active_tab
@@ -57,6 +75,11 @@ class Tabs(BaseComponent):
         return dbc_tabs
 
     def render(self):
+        """Render the tabs and their content as a ``dbc.Tabs`` component.
+
+        Returns:
+            dbc.Tabs: The Dash Bootstrap tabs component with its child tabs.
+        """
         # Determine the default active tab if not specified
         active_tab_id = self.active_tab
         if active_tab_id is None and self.tabs_data:


### PR DESCRIPTION
## Summary
- add Google-style docstrings to `__init__` and `render` for ComboBox, Container, ListBox, RadioButton, Graph and Tabs

## Testing
- `ruff check .` *(fails: import sorting, unused imports, line length)*
- `mypy --strict .` *(fails: duplicate module named `conftest`)*
- `python -m pytest -q` *(fails: No module named pytest)*