### PR TITLE
Add missing docstrings for movement utilities

### DIFF
--- a/src/PricingMonkey/pMoneyMovement.py
+++ b/src/PricingMonkey/pMoneyMovement.py
@@ -192,6 +192,7 @@ def split_dataframe_by_expiry(df):
     
     # Extract expiry from Trade Description column
     def extract_expiry(desc):
+        """Return the expiry keyword from an option description string."""
         if not isinstance(desc, str):
             return None
         words = desc.split()
@@ -244,6 +245,7 @@ def split_dataframe_by_expiry_and_underlying(df):
     
     # Extract expiry from Trade Description column
     def extract_expiry(desc):
+        """Return the expiry keyword from an option description string."""
         if not isinstance(desc, str):
             return None
         words = desc.split()

--- a/src/lumberjack/sqlite_handler.py
+++ b/src/lumberjack/sqlite_handler.py
@@ -17,6 +17,11 @@ class SQLiteHandler(logging.Handler):
     - Ignores other log messages.
     """
     def __init__(self, db_filename='function_logs.db'):
+        """Initialize the handler and create required tables if needed.
+
+        Args:
+            db_filename: Path to the SQLite database used for logging.
+        """
         super().__init__()
         self.db_filename = db_filename
         self.conn = None


### PR DESCRIPTION
## Summary
- document `SQLiteHandler.__init__`
- add docstrings for the internal `extract_expiry` helpers

## Testing
- `ruff check .` *(fails: 551 errors, imports and formatting)*
- `mypy --strict .` *(fails: Duplicate module named "conftest")*
- `pytest -q` *(fails: command not found)*