### PR TITLE
Add docstrings for SQLite handler and helper functions

### DIFF
--- a/src/PricingMonkey/pMoneyMovement.py
+++ b/src/PricingMonkey/pMoneyMovement.py
@@ -191,7 +191,17 @@ def split_dataframe_by_expiry(df):
         return {'1st': df}  # Return original DataFrame as fallback
     
     # Extract expiry from Trade Description column
-    def extract_expiry(desc):
+    def extract_expiry(desc: str | None) -> str | None:
+        """Extract the expiry token from a trade description string.
+
+        Args:
+            desc: The full trade description, expected to start with the
+                expiry label (e.g., ``"1st ZN Mar25"``).
+
+        Returns:
+            The expiry label (``"1st"``) if present, otherwise ``None``.
+        """
+
         if not isinstance(desc, str):
             return None
         words = desc.split()
@@ -243,7 +253,17 @@ def split_dataframe_by_expiry_and_underlying(df):
         }
     
     # Extract expiry from Trade Description column
-    def extract_expiry(desc):
+    def extract_expiry(desc: str | None) -> str | None:
+        """Extract the expiry token from a trade description string.
+
+        Args:
+            desc: The full trade description, expected to start with the
+                expiry label (for example ``"2nd ZN Jun25"``).
+
+        Returns:
+            The expiry label if present, otherwise ``None``.
+        """
+
         if not isinstance(desc, str):
             return None
         words = desc.split()

--- a/src/lumberjack/sqlite_handler.py
+++ b/src/lumberjack/sqlite_handler.py
@@ -16,7 +16,14 @@ class SQLiteHandler(logging.Handler):
     - Aggregates performance metrics into the 'AveragePerformance' table.
     - Ignores other log messages.
     """
-    def __init__(self, db_filename='function_logs.db'):
+    def __init__(self, db_filename: str = "function_logs.db"):
+        """Initialize the handler and set up the SQLite database.
+
+        Args:
+            db_filename: Path to the SQLite database file. A new file is
+                created if it does not already exist.
+        """
+
         super().__init__()
         self.db_filename = db_filename
         self.conn = None


### PR DESCRIPTION
## Summary
- document `SQLiteHandler.__init__`
- add docstrings to nested `extract_expiry` helpers in market movement module

## Testing
- `ruff check .` *(fails: import order issues in TTRestAPI package)*
- `mypy --strict .` *(fails: duplicate module named "conftest")*
- `pytest -q` *(fails: command not found)*