### PR TITLE
Add mermaid render test

### DIFF
--- a/memory-bank/code-index.md
+++ b/memory-bank/code-index.md
@@ -71,3 +71,7 @@
 - `TTRestAPI/examples/get_my_algo_ids.py` - Fetches and lists ADL algorithm IDs and names.
 - `TTRestAPI/examples/get_algo_orders.py` - Fetches working orders, with logic to identify orders related to a specific algorithm.
 - `TTRestAPI/examples/get_order_enumerations.py` - Fetches and saves enumeration definitions (e.g., for order status, side, type) from the `/ttledger/orderdata` endpoint.
+
+## Tests
+
+- `tests/components/test_mermaid_render.py` - Unit tests for `Mermaid.render` verifying ID propagation, theme styling, and default config merging.

--- a/tests/components/test_mermaid_render.py
+++ b/tests/components/test_mermaid_render.py
@@ -1,0 +1,19 @@
+from pytest_mock import MockerFixture  # type: ignore
+
+from components.mermaid import Mermaid  # type: ignore
+from utils.colour_palette import default_theme  # type: ignore
+
+
+def test_mermaid_render_basic(mocker: MockerFixture) -> None:
+    mermaid_mock = mocker.patch("components.mermaid.dash_extensions.Mermaid")
+    m = Mermaid()
+    div = m.render("diag-1", "graph TD; A-->B")
+
+    mermaid_mock.assert_called_once()
+    call_kwargs = mermaid_mock.call_args.kwargs
+    assert call_kwargs["id"] == "diag-1"
+    assert call_kwargs["chart"] == "graph TD; A-->B"
+    assert call_kwargs["config"]["theme"] == m.default_styles["mermaid_config"]["theme"]
+
+    assert div.children[-1] is mermaid_mock.return_value
+    assert div.style["backgroundColor"] == default_theme.panel_bg


### PR DESCRIPTION
## Summary
- test Mermaid.render with mocks
- document test file in code index

## Testing
- `ruff check tests/components/test_mermaid_render.py`
- `mypy --strict tests/components/test_mermaid_render.py`
- `python3 -m pytest -q tests/components/test_mermaid_render.py` *(fails: No module named pytest)*