### PR TITLE
Add BaseComponent tests

### DIFF
--- a/memory-bank/code-index.md
+++ b/memory-bank/code-index.md
@@ -74,4 +74,5 @@
 
 ## Tests
 - `tests/components/test_container_render.py` - Unit tests verifying `Container.render` child handling and theme styles.
+- `tests/core/test_base_component.py` - Unit tests verifying ID validation and default theme usage in `BaseComponent`.
 

--- a/tests/core/test_base_component.py
+++ b/tests/core/test_base_component.py
@@ -1,0 +1,22 @@
+import pytest
+
+from core.base_component import BaseComponent
+from utils.colour_palette import default_theme
+
+
+class DummyComponent(BaseComponent):  # type: ignore[misc]
+    """Minimal subclass for testing BaseComponent."""
+
+    def render(self) -> dict[str, object]:
+        return {"id": self.id, "theme": self.theme}
+
+
+def test_base_component_requires_id() -> None:
+    with pytest.raises(ValueError):
+        DummyComponent(id=None)
+
+
+def test_base_component_default_theme() -> None:
+    comp = DummyComponent("dummy")
+    assert comp.theme is default_theme
+


### PR DESCRIPTION
## Summary
- add tests for BaseComponent to check ID validation and theme defaults
- document new tests in code-index

## Testing
- `ruff check tests/core/test_base_component.py --fix`
- `mypy --strict --ignore-missing-imports tests/core/test_base_component.py`
- `python -m pytest -q tests/core/test_base_component.py` *(fails: No module named pytest)*