### PR TITLE
Rewrite TraceCloser tests

### DIFF
--- a/tests/decorators/test_trace_closer.py
+++ b/tests/decorators/test_trace_closer.py
@@ -1,37 +1,93 @@
 # tests/decorators/test_trace_closer.py
 
-import pytest
 import logging
-import json
 import uuid
-import time
-import contextvars
-from unittest.mock import patch, MagicMock
+from typing import Any
 
-# Assuming 'src' is accessible in the path for imports
-from decorators.trace_closer import TraceCloser
-# --- Corrected: Import specific context var instances used in trace_closer ---
-from decorators.trace_closer import log_uuid_var, current_log_data
-# ---
-from decorators.trace_time import TraceTime # For stacking
-from decorators.trace_cpu import TraceCpu   # For stacking
-from decorators.trace_memory import TraceMemory # For stacking
+import pytest  # type: ignore[import-not-found]
 
-# Use the shared fixtures from tests/decorators/conftest.py
-# setup_logging_context fixture is applied automatically via autouse=True
-# mock_psutil_process and mock_psutil_cpu fixtures are available
+from decorators.trace_closer import TraceCloser, current_log_data, log_uuid_var  # type: ignore[import-not-found]
+from decorators.trace_cpu import TraceCpu  # type: ignore[import-not-found]
+from decorators.trace_memory import TraceMemory  # type: ignore[import-not-found]
+from decorators.trace_time import TraceTime  # type: ignore[import-not-found]
 
 # --- Test Functions ---
 
-# test_trace_closer_generates_uuid_if_none remains the same
-# test_trace_closer_uses_existing_uuid remains the same
-# test_trace_closer_exception_logging remains the same
-# test_trace_closer_stacking remains the same
+def test_trace_closer_generates_uuid_if_none(caplog: pytest.LogCaptureFixture) -> None:
+    """TraceCloser should create a UUID when none exists."""
+    caplog.set_level(logging.INFO)
+    token_uuid = log_uuid_var.set(None)
+    token_data = current_log_data.set(None)
 
-# --- REMOVED test_trace_closer_handles_context_reset_failure ---
-# This test is removed because reliably mocking ContextVar.reset failure
-# with unittest.mock is problematic.
+    @TraceCloser()  # type: ignore[misc]
+    def func() -> str:
+        return log_uuid_var.get() or ""
 
-# test_trace_closer_existing_uuid_no_data remains the same
+    generated = func()
 
-# (Include the unchanged test functions here if providing the full file)
+    assert uuid.UUID(generated)  # Valid UUID
+    assert log_uuid_var.get() is None
+    assert current_log_data.get() is None
+    assert any(record.getMessage().startswith(TraceCloser.FLOW_TRACE_PREFIX) for record in caplog.records)
+
+    log_uuid_var.reset(token_uuid)
+    current_log_data.reset(token_data)
+
+
+def test_trace_closer_uses_existing_uuid(setup_logging_context: tuple[str, dict[str, Any]]) -> None:
+    """TraceCloser should reuse an existing UUID."""
+    test_uuid, _ = setup_logging_context
+
+    @TraceCloser()  # type: ignore[misc]
+    def func() -> str:
+        return log_uuid_var.get() or ""
+
+    result = func()
+
+    assert result == test_uuid
+    assert log_uuid_var.get() == test_uuid
+
+
+def test_trace_closer_exception_logging(caplog: pytest.LogCaptureFixture) -> None:
+    """Exceptions raised inside the wrapped function are logged."""
+    caplog.set_level(logging.ERROR)
+
+    @TraceCloser()  # type: ignore[misc]
+    def boom() -> None:
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        boom()
+
+    assert any("Exception in boom" in r.getMessage() for r in caplog.records)
+
+
+def test_trace_closer_stacking(
+    caplog: pytest.LogCaptureFixture,
+    setup_logging_context: tuple[str, dict[str, Any]],
+    mock_psutil_process: Any,
+    mock_psutil_cpu: Any,
+) -> None:
+    """Metrics from stacked decorators should appear in the context."""
+    test_uuid, data = setup_logging_context
+    caplog.set_level(logging.INFO)
+
+    mock_psutil_process.memory_info.side_effect = [
+        type("M", (), {"rss": 100 * 1024 * 1024})(),
+        type("M", (), {"rss": 104 * 1024 * 1024})(),
+    ]
+
+    mock_psutil_cpu.side_effect = [10.0, 15.0]
+
+    @TraceCloser()  # type: ignore[misc]
+    @TraceCpu()  # type: ignore[misc]
+    @TraceMemory()  # type: ignore[misc]
+    @TraceTime(log_args=False, log_return=False)  # type: ignore[misc]
+    def work(x: int) -> int:
+        return x * 2
+
+    assert work(3) == 6
+    assert data.get("duration_s") is not None
+    assert data.get("cpu_delta") == 5.0
+    assert data.get("memory_delta_mb") == pytest.approx(4.0, rel=0.01)
+    assert any(record.getMessage().startswith(TraceCloser.FLOW_TRACE_PREFIX) for record in caplog.records)


### PR DESCRIPTION
## Summary
- add full tests for TraceCloser covering
  - UUID creation when context is empty
  - usage of an existing UUID
  - exception logging
  - decorator stacking with TraceTime/TraceCpu/TraceMemory

## Testing
- `ruff check tests/decorators/test_trace_closer.py`
- `mypy --strict tests/decorators/test_trace_closer.py`
- `pip install pytest` *(fails: Could not connect to proxy)*