### PR TITLE
Add tt_utils tests

### DIFF
--- a/TTRestAPI/README.md
+++ b/TTRestAPI/README.md
@@ -61,6 +61,8 @@ from TTRestAPI.tt_utils import (
 auth_header_value = format_bearer_token("my_token")
 ```
 
+Unit tests in `tests/ttapi/test_tt_utils.py` verify GUID generation, request ID formatting, and sanitize logic.
+
 ### `api_example.py`
 
 A comprehensive example of how to use the package to make API requests to different TT REST API services.

--- a/memory-bank/code-index.md
+++ b/memory-bank/code-index.md
@@ -71,3 +71,6 @@
 - `TTRestAPI/examples/get_my_algo_ids.py` - Fetches and lists ADL algorithm IDs and names.
 - `TTRestAPI/examples/get_algo_orders.py` - Fetches working orders, with logic to identify orders related to a specific algorithm.
 - `TTRestAPI/examples/get_order_enumerations.py` - Fetches and saves enumeration definitions (e.g., for order status, side, type) from the `/ttledger/orderdata` endpoint.
+
+### Tests (`tests/ttapi/`)
+- `tests/ttapi/test_tt_utils.py` - Unit tests for GUID generation, request ID formatting, and sanitization logic in `tt_utils`.

--- a/tests/ttapi/test_tt_utils.py
+++ b/tests/ttapi/test_tt_utils.py
@@ -1,0 +1,27 @@
+import re
+
+from TTRestAPI.tt_utils import (
+    create_request_id,
+    generate_guid,
+    is_valid_guid,
+    sanitize_request_id_part,
+)
+
+
+def test_generate_guid_is_valid() -> None:
+    guid = generate_guid()
+    assert is_valid_guid(guid)
+
+
+def test_create_request_id_format() -> None:
+    req_id = create_request_id("My App", "Acme Co")
+    prefix, guid = req_id.split("--")
+    assert prefix == "My_App-Acme_Co"
+    assert is_valid_guid(guid)
+
+
+def test_sanitize_request_id_part() -> None:
+    text = "My @App/Name"
+    sanitized = sanitize_request_id_part(text)
+    assert sanitized == "My_AppName"
+


### PR DESCRIPTION
## Summary
- add tests for TT REST API utilities
- document new tests in README and memory bank

## Testing
- `ruff check TTRestAPI/tt_utils.py tests/ttapi/test_tt_utils.py`
- `mypy --strict TTRestAPI/tt_utils.py tests/ttapi/test_tt_utils.py`
- `python -m pytest -q tests/ttapi/test_tt_utils.py` *(fails: No module named pytest)*