### PR TITLE
Add ladder scenario tests

### DIFF
--- a/memory-bank/code-index.md
+++ b/memory-bank/code-index.md
@@ -54,6 +54,7 @@
 - `ladderTest/price_formatter.py` - Utility function to convert decimal prices to TT bond-style string notation (e.g., "110'005").
 - `ladderTest/scenario_ladder_v1.py` - Dash application that displays a scenario ladder based on live working orders fetched from the TT REST API or mock data. It shows prices and user's order quantities with uniform price increments, filling in gaps between actual orders. PnL is calculated based on the position before any orders at the current level, while position_debug shows the accumulated position after orders at that level are executed. The risk column displays position multiplied by 15.625 to represent DV01 risk. Includes mock spot price functionality (110'085) when in mock data mode. Recently fixed a bug where a callback returned an incorrect number of outputs when no working orders were found.
 - `ladderTest/csv_to_sqlite.py` - Helper module for converting CSV data to SQLite database tables with query utilities.
+- `tests/ladderTest/test_scenario_ladder_v1.py` - Unit tests covering price ladder calculations and PnL updates with mocked TT REST API responses.
 
 ## TT REST API Integration (TTRestAPI/)
 

--- a/tests/ladderTest/test_scenario_ladder_v1.py
+++ b/tests/ladderTest/test_scenario_ladder_v1.py
@@ -1,0 +1,50 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure repo root is on the path so ladderTest modules can be imported
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from ladderTest import scenario_ladder_v1 as slv  # noqa: E402
+
+
+def test_update_data_with_spot_price_basic(mocker):
+    """Validate PnL and position calculation around spot price."""
+    # Patch requests.get to ensure no network access
+    mocker.patch.object(slv, "requests")
+
+    existing = [
+        {"price": "110'105", "decimal_price_val": 110.328125, "my_qty": "", "working_qty_side": ""},
+        {"price": "110'100", "decimal_price_val": 110.3125, "my_qty": "2", "working_qty_side": "1"},
+        {"price": "110'095", "decimal_price_val": 110.296875, "my_qty": "1", "working_qty_side": "2"},
+    ]
+    spot = {"decimal_price": 110.3125, "special_string_price": "110'100"}
+
+    result = slv.update_data_with_spot_price(existing, spot, base_position=0, base_pnl=0.0)
+
+    assert result[1]["is_exact_spot"] == 1
+    assert result[1]["position_debug"] == 2
+    assert result[2]["projected_pnl"] == -31.25
+    assert result[2]["breakeven"] == -2.0
+
+
+def test_update_data_with_spot_price_with_baseline(mocker):
+    """Ensure baseline position and PnL feed into projections."""
+    mocker.patch.object(slv, "requests")
+
+    existing = [
+        {"price": "110'100", "decimal_price_val": 110.3125, "my_qty": "", "working_qty_side": ""},
+        {"price": "110'095", "decimal_price_val": 110.296875, "my_qty": "2", "working_qty_side": "2"},
+    ]
+    spot = {"decimal_price": 110.3125, "special_string_price": "110'100"}
+
+    result = slv.update_data_with_spot_price(existing, spot, base_position=5, base_pnl=50.0)
+
+    assert result[0]["projected_pnl"] == 50.0
+    assert result[0]["position_debug"] == 5
+    # Projected PnL after sell order should decrease accordingly
+    assert pytest.approx(result[1]["projected_pnl"], abs=0.01) == -28.12
+    assert result[1]["position_debug"] == 3


### PR DESCRIPTION
## Summary
- add tests for `scenario_ladder_v1.update_data_with_spot_price`
- document the new test in the code index

## Testing
- `ruff check tests/ladderTest/test_scenario_ladder_v1.py`
- `mypy --strict tests/ladderTest/test_scenario_ladder_v1.py` *(fails: missing type stubs and annotations)*
- `python -m pytest tests/ladderTest/test_scenario_ladder_v1.py -q` *(fails: no pytest installed)*