### PR TITLE
Add dashboard callback tests

### DIFF
--- a/memory-bank/code-index.md
+++ b/memory-bank/code-index.md
@@ -71,3 +71,7 @@
 - `TTRestAPI/examples/get_my_algo_ids.py` - Fetches and lists ADL algorithm IDs and names.
 - `TTRestAPI/examples/get_algo_orders.py` - Fetches working orders, with logic to identify orders related to a specific algorithm.
 - `TTRestAPI/examples/get_order_enumerations.py` - Fetches and saves enumeration definitions (e.g., for order status, side, type) from the `/ttledger/orderdata` endpoint.
+
+## Tests
+
+- `tests/dashboard/test_dashboard_callbacks.py` - Unit tests for dashboard callbacks such as option block updates and log refresh logic.

--- a/tests/dashboard/test_dashboard_callbacks.py
+++ b/tests/dashboard/test_dashboard_callbacks.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import patch
+
+from dashboard import dashboard as dash_module
+
+dashboard_mod = cast(Any, dash_module)
+
+
+def test_update_option_blocks_valid() -> None:
+    children = dashboard_mod.update_option_blocks("2")
+    assert len(children) == 3
+    assert children[0].style["display"] == "block"
+    assert children[1].style["display"] == "block"
+    assert children[2].style["display"] == "none"
+
+
+def test_update_option_blocks_invalid() -> None:
+    children = dashboard_mod.update_option_blocks("foo")
+    assert len(children) == 3
+    assert [c.style["display"] for c in children] == ["block", "none", "none"]
+
+
+from _pytest.monkeypatch import MonkeyPatch
+
+
+def test_refresh_log_data(monkeypatch: MonkeyPatch) -> None:
+    flow = [{"id": 1}]
+    perf = [{"fn": "a"}]
+
+    monkeypatch.setattr(dashboard_mod, "query_flow_trace_logs", lambda limit=100: flow)
+    monkeypatch.setattr(dashboard_mod, "query_performance_metrics", lambda: perf)
+
+    out_flow, out_perf = dashboard_mod.refresh_log_data(1)
+    assert out_flow == flow
+    assert out_perf == perf
+
+
+class DummyCtx(SimpleNamespace):
+    pass
+
+
+def test_toggle_logs_tables_performance() -> None:
+    ctx = DummyCtx(triggered=[{"prop_id": "logs-toggle-performance.n_clicks"}])
+    with patch.object(dashboard_mod.dash, "callback_context", ctx):
+        flow_style, perf_style, flow_btn, perf_btn = dashboard_mod.toggle_logs_tables(1, 2)
+    assert flow_style["display"] == "none"
+    assert perf_style["display"] == "block"
+    assert perf_btn["backgroundColor"] == dashboard_mod.default_theme.primary
+    assert flow_btn["backgroundColor"] == dashboard_mod.default_theme.panel_bg
+
+
+def test_toggle_logs_tables_default() -> None:
+    ctx = DummyCtx(triggered=[])
+    with patch.object(dashboard_mod.dash, "callback_context", ctx):
+        flow_style, perf_style, flow_btn, perf_btn = dashboard_mod.toggle_logs_tables(None, None)
+    assert flow_style["display"] == "block"
+    assert perf_style["display"] == "none"
+    assert flow_btn["backgroundColor"] == dashboard_mod.default_theme.primary
+    assert perf_btn["backgroundColor"] == dashboard_mod.default_theme.panel_bg


### PR DESCRIPTION
## Summary
- add regression tests for dashboard callbacks like `update_option_blocks`
- document new test file in `code-index.md`

## Testing
- `ruff check tests/dashboard/test_dashboard_callbacks.py`
- `mypy --strict --ignore-missing-imports --follow-imports=skip tests/dashboard/test_dashboard_callbacks.py`
- `pip install pytest` *(fails: cannot connect to proxy)*