### PR TITLE
Add mermaid protocol unit test

### DIFF
--- a/memory-bank/code-index.md
+++ b/memory-bank/code-index.md
@@ -80,6 +80,7 @@
 
 - `tests/components/test_container_render.py` - Unit tests verifying `Container.render` child handling and theme styles.
 - `tests/core/test_base_component.py` - Unit tests verifying ID validation and default theme usage in `BaseComponent`.
+- `tests/core/test_mermaid_protocol.py` - Ensures abstract methods defined in `MermaidProtocol` return expected structures when implemented.
 
 
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -34,6 +34,7 @@
 - Applied to both calculation passes (above and below spot price)
 - Maintains existing position_debug column for raw position display
 - No changes to PnL calculation logic
+- Added unit test `tests/core/test_mermaid_protocol.py` with a dummy subclass to verify MermaidProtocol method outputs
 
 ## 2023-11-14 Project Restructuring
 

--- a/tests/core/test_mermaid_protocol.py
+++ b/tests/core/test_mermaid_protocol.py
@@ -1,0 +1,23 @@
+from core.mermaid_protocol import MermaidProtocol
+
+
+class DummyMermaid(MermaidProtocol):
+    """Minimal concrete implementation for testing."""
+
+    def render(self, id: str, graph_definition: str, **kwargs) -> dict[str, object]:
+        return {"id": id, "graph": graph_definition, "kwargs": kwargs}
+
+    def apply_theme(self, theme_config: dict[str, object]) -> dict[str, object]:
+        return {"applied": theme_config}
+
+
+def test_dummy_mermaid_render() -> None:
+    dummy = DummyMermaid()
+    result = dummy.render("d1", "graph TD; A-->B", extra=1)
+    assert result == {"id": "d1", "graph": "graph TD; A-->B", "kwargs": {"extra": 1}}
+
+
+def test_dummy_mermaid_apply_theme() -> None:
+    dummy = DummyMermaid()
+    config = {"theme": "dark"}
+    assert dummy.apply_theme(config) == {"applied": config}


### PR DESCRIPTION
## Summary
- add DummyMermaid test verifying protocol methods
- document test file in the code index and progress log

## Testing
- `ruff check .` *(fails: import sorting issues in repo)*
- `mypy --strict src tests` *(fails: duplicate module named "conftest")*
- `pytest -q` *(fails: command not found)*