### PR TITLE
Expand SQLite handler tests

### DIFF
--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -102,6 +102,8 @@
   - Added DataTable entries to io-schema.md
   - Updated demo files in code-index.md
   - Added decorator configuration entries to io-schema.md
+  - Added tests for invalid JSON, schema errors, and repeated close operations in
+    `tests/lumberjack/test_sqlite_handler.py`
 
 ### Next Steps
 - Create integration tests for all decorators working together


### PR DESCRIPTION
## Summary
- test sqlite flow trace invalid JSON handling
- test idempotent close
- test initialization failure via monkeypatch
- document new lumberjack scenarios in progress

## Testing
- `ruff check .`
- `mypy --strict src`
- `python -m pytest -q`