### PR TITLE
Add unit tests for bond price formatter utilities

### DIFF
--- a/memory-bank/code-index.md
+++ b/memory-bank/code-index.md
@@ -55,6 +55,7 @@
 - `ladderTest/scenario_ladder_v1.py` - Dash application that displays a scenario ladder based on live working orders fetched from the TT REST API or mock data. It shows prices and user's order quantities with uniform price increments, filling in gaps between actual orders. PnL is calculated based on the position before any orders at the current level, while position_debug shows the accumulated position after orders at that level are executed. The risk column displays position multiplied by 15.625 to represent DV01 risk. Includes mock spot price functionality (110'085) when in mock data mode. Recently fixed a bug where a callback returned an incorrect number of outputs when no working orders were found.
 - `ladderTest/csv_to_sqlite.py` - Helper module for converting CSV data to SQLite database tables with query utilities.
 - `tests/ladderTest/test_csv_to_sqlite.py` - Unit tests for the CSV-to-SQLite conversion helpers.
+- `tests/ladderTest/test_price_formatter.py` - Unit tests for TT bond price conversion utilities.
 
 ## TT REST API Integration (TTRestAPI/)
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -179,6 +179,7 @@
 - Added graceful fallback to direct CSV reading if SQLite operations fail
 - Fixed a bug in `scenario_ladder_v1.py` where a callback would return an incorrect number of outputs if no working orders were found, by ensuring default baseline data is returned.
 - Added unit tests for `csv_to_sqlite_table`, `get_table_schema`, and `query_sqlite_table`.
+- Added unit tests for TT bond price conversion utilities.
 
 ## In Progress
 - Verifying fill price parsing logic is correct for Actant data (from `110'065` format)

--- a/tests/ladderTest/test_price_formatter.py
+++ b/tests/ladderTest/test_price_formatter.py
@@ -1,0 +1,41 @@
+import math
+
+import pytest
+
+from ladderTest.price_formatter import decimal_to_tt_bond_format
+from ladderTest.scenario_ladder_v1 import convert_tt_special_format_to_decimal
+
+
+@pytest.mark.parametrize(
+    "decimal", [0.0, 0.015625, 1.0, 1.515625, 110.0, 110.015625, 110.03125, 109.984375]
+)
+def test_round_trip_conversion(decimal: float) -> None:
+    """Convert decimal to TT string and back, verifying identity."""
+    special = decimal_to_tt_bond_format(decimal)
+    result = convert_tt_special_format_to_decimal(special)
+    assert result is not None
+    assert math.isclose(result, decimal, rel_tol=1e-9)
+
+
+@pytest.mark.parametrize(
+    "price_str,expected",
+    [
+        ("110'085", 110 + 8.5 / 32),
+        ("110'0875", 110 + 8.75 / 32),
+        ("110'08", 110 + 8 / 32),
+        ("0'005", 0.015625),
+    ],
+)
+def test_convert_tt_special_format_to_decimal(price_str: str, expected: float) -> None:
+    """Verify parsing of explicit TT bond price strings."""
+    result = convert_tt_special_format_to_decimal(price_str)
+    assert result is not None
+    assert math.isclose(result, expected, rel_tol=1e-9)
+
+
+def test_invalid_inputs() -> None:
+    """Invalid input cases return None or raise TypeError."""
+    assert convert_tt_special_format_to_decimal("bad") is None
+    with pytest.raises(TypeError):
+        decimal_to_tt_bond_format("bad")
+


### PR DESCRIPTION
## Summary
- test round-trip conversions to/from TT bond price strings
- document new tests in code index and progress log

## Testing
- `ruff check tests/ladderTest/test_price_formatter.py --quiet`
- `mypy --strict tests/ladderTest/test_price_formatter.py`
- `python -m pytest -q tests/ladderTest/test_price_formatter.py` *(fails: No module named 'pytest')*