### PR TITLE
Add docstrings to tests

### DIFF
--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -150,9 +150,10 @@
 
 - Improved docstring consistency throughout the codebase [May 10, 2025]
   - Added comprehensive Google-style docstrings to all functions and classes
-  - Standardized docstring format across all modules
-  - Focused on decorator modules, components, and utility functions
-  - No functional code changes were made during this task
+- Standardized docstring format across all modules
+- Focused on decorator modules, components, and utility functions
+- No functional code changes were made during this task
+- Added Google-style docstrings to all test functions for clarity [May 26, 2025]
 
 # Progress Tracking
 

--- a/tests/components/test_button_render.py
+++ b/tests/components/test_button_render.py
@@ -2,7 +2,8 @@ from components.button import Button
 from utils.colour_palette import default_theme
 
 
-def test_button_render():
+def test_button_render() -> None:
+    """Render a Button and verify default properties."""
     btn = Button("Refresh").render()
 
     # minimal snapshot: children, id, bootstrap colour & inline style keys

--- a/tests/components/test_combobox_render.py
+++ b/tests/components/test_combobox_render.py
@@ -2,7 +2,8 @@ from components.combobox import ComboBox
 from utils.colour_palette import default_theme
 
 
-def test_combobox_render():
+def test_combobox_render() -> None:
+    """Render a ComboBox and verify option mapping and styling."""
     cb = ComboBox(["A", "B", "C"]).render()
 
     assert cb.id.startswith("combo-")

--- a/tests/components/test_container_render.py
+++ b/tests/components/test_container_render.py
@@ -3,7 +3,8 @@ from components.container import Container
 from utils.colour_palette import default_theme
 
 
-def test_container_single_child():
+def test_container_single_child() -> None:
+    """Container renders correctly with a single child."""
     container = Container(
         id="cont-1",
         children=Button(id="btn-1", label="OK")
@@ -14,7 +15,8 @@ def test_container_single_child():
     assert container.style["backgroundColor"] == default_theme.panel_bg
 
 
-def test_container_multiple_children():
+def test_container_multiple_children() -> None:
+    """Container renders multiple children in order."""
     container = Container(
         id="cont-2",
         children=[Button(id="btn-a"), Button(id="btn-b")]
@@ -24,7 +26,8 @@ def test_container_multiple_children():
     assert container.style["padding"] == "15px"
 
 
-def test_container_nested_list_children():
+def test_container_nested_list_children() -> None:
+    """Nested lists are flattened when rendering children."""
     container = Container(
         id="cont-3",
         children=[[Button(id="btn-x"), Button(id="btn-y")], Button(id="btn-z")]

--- a/tests/components/test_graph_render.py
+++ b/tests/components/test_graph_render.py
@@ -2,7 +2,8 @@ from components.graph import Graph
 from utils.colour_palette import default_theme
 
 
-def test_graph_render():
+def test_graph_render() -> None:
+    """Render Graph component with default settings."""
     g = Graph({}).render()  # empty figure dict
 
     assert g.id.startswith("graph-")

--- a/tests/components/test_grid_render.py
+++ b/tests/components/test_grid_render.py
@@ -2,12 +2,14 @@ from components.button import Button
 from components.grid import Grid
 
 
-def test_grid_even_split():
+def test_grid_even_split() -> None:
+    """Grid evenly distributes columns by default."""
     g = Grid([Button("A"), Button("B"), Button("C")]).render()
     assert [c.width for c in g.children] == [4, 4, 4]
 
 
-def test_grid_custom_widths():
+def test_grid_custom_widths() -> None:
+    """Grid respects custom column widths."""
     g = Grid(
         [Button("Left"), Button("Right")],
         col_widths=[3, 9],

--- a/tests/components/test_listbox_render.py
+++ b/tests/components/test_listbox_render.py
@@ -2,7 +2,8 @@ from components.listbox import ListBox
 from utils.colour_palette import default_theme
 
 
-def test_listbox_render():
+def test_listbox_render() -> None:
+    """Render ListBox with single value pre-selected."""
     lb = ListBox(["One", "Two", "Three"], values=["Two"]).render()
 
     assert lb.id.startswith("listbox-")

--- a/tests/components/test_mermaid_render.py
+++ b/tests/components/test_mermaid_render.py
@@ -5,6 +5,7 @@ from utils.colour_palette import default_theme  # type: ignore
 
 
 def test_mermaid_render_basic(mocker: MockerFixture) -> None:
+    """Ensure Mermaid component renders and forwards config."""
     mermaid_mock = mocker.patch("components.mermaid.dash_extensions.Mermaid")
     m = Mermaid()
     div = m.render("diag-1", "graph TD; A-->B")

--- a/tests/components/test_radiobutton_render.py
+++ b/tests/components/test_radiobutton_render.py
@@ -2,7 +2,8 @@ from components.radiobutton import RadioButton
 from utils.colour_palette import default_theme
 
 
-def test_radiobutton_render():
+def test_radiobutton_render() -> None:
+    """Render RadioButton and check selected state."""
     rb = RadioButton(["Red", "Blue"], value="Blue").render()
 
     assert rb.id.startswith("radio-")

--- a/tests/components/test_tabs_render.py
+++ b/tests/components/test_tabs_render.py
@@ -5,7 +5,8 @@ from components.tabs import Tabs
 from utils.colour_palette import default_theme
 
 
-def test_tabs_render():
+def test_tabs_render() -> None:
+    """Render Tabs component and verify active tab styling."""
     tab_a = Button("A")
     tab_b = Button("B")
     tabs_wrapper = Tabs([("First", tab_a), ("Second", tab_b)], active_tab_index=1)

--- a/tests/core/test_base_component.py
+++ b/tests/core/test_base_component.py
@@ -12,11 +12,13 @@ class DummyComponent(BaseComponent):  # type: ignore[misc]
 
 
 def test_base_component_requires_id() -> None:
+    """BaseComponent must raise when id is missing."""
     with pytest.raises(ValueError):
         DummyComponent(id=None)
 
 
 def test_base_component_default_theme() -> None:
+    """Components default to the global theme."""
     comp = DummyComponent("dummy")
     assert comp.theme is default_theme
 

--- a/tests/core/test_mermaid_protocol.py
+++ b/tests/core/test_mermaid_protocol.py
@@ -1,7 +1,7 @@
 from core.mermaid_protocol import MermaidProtocol
 
 
-class DummyMermaid(MermaidProtocol):
+class DummyMermaid(MermaidProtocol):  # type: ignore[misc]
     """Minimal concrete implementation for testing."""
 
     def render(self, id: str, graph_definition: str, **kwargs) -> dict[str, object]:
@@ -12,12 +12,14 @@ class DummyMermaid(MermaidProtocol):
 
 
 def test_dummy_mermaid_render() -> None:
+    """DummyMermaid.render returns expected structure."""
     dummy = DummyMermaid()
     result = dummy.render("d1", "graph TD; A-->B", extra=1)
     assert result == {"id": "d1", "graph": "graph TD; A-->B", "kwargs": {"extra": 1}}
 
 
 def test_dummy_mermaid_apply_theme() -> None:
+    """DummyMermaid.apply_theme echoes configuration."""
     dummy = DummyMermaid()
     config = {"theme": "dark"}
     assert dummy.apply_theme(config) == {"applied": config}

--- a/tests/dashboard/test_dashboard_callbacks.py
+++ b/tests/dashboard/test_dashboard_callbacks.py
@@ -2,12 +2,15 @@ from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import patch
 
+from _pytest.monkeypatch import MonkeyPatch
+
 from dashboard import dashboard as dash_module
 
 dashboard_mod = cast(Any, dash_module)
 
 
 def test_update_option_blocks_valid() -> None:
+    """Updating option blocks with numeric input shows correct fields."""
     children = dashboard_mod.update_option_blocks("2")
     assert len(children) == 3
     assert children[0].style["display"] == "block"
@@ -16,15 +19,14 @@ def test_update_option_blocks_valid() -> None:
 
 
 def test_update_option_blocks_invalid() -> None:
+    """Invalid input hides all but the first option block."""
     children = dashboard_mod.update_option_blocks("foo")
     assert len(children) == 3
     assert [c.style["display"] for c in children] == ["block", "none", "none"]
 
 
-from _pytest.monkeypatch import MonkeyPatch
-
-
 def test_refresh_log_data(monkeypatch: MonkeyPatch) -> None:
+    """Refresh log data returns latest flow and performance entries."""
     flow = [{"id": 1}]
     perf = [{"fn": "a"}]
 
@@ -41,6 +43,7 @@ class DummyCtx(SimpleNamespace):
 
 
 def test_toggle_logs_tables_performance() -> None:
+    """Clicking performance toggle shows performance table."""
     ctx = DummyCtx(triggered=[{"prop_id": "logs-toggle-performance.n_clicks"}])
     with patch.object(dashboard_mod.dash, "callback_context", ctx):
         flow_style, perf_style, flow_btn, perf_btn = dashboard_mod.toggle_logs_tables(1, 2)
@@ -51,6 +54,7 @@ def test_toggle_logs_tables_performance() -> None:
 
 
 def test_toggle_logs_tables_default() -> None:
+    """No toggle clicks defaults to flow trace view."""
     ctx = DummyCtx(triggered=[])
     with patch.object(dashboard_mod.dash, "callback_context", ctx):
         flow_style, perf_style, flow_btn, perf_btn = dashboard_mod.toggle_logs_tables(None, None)

--- a/tests/ladderTest/test_csv_to_sqlite.py
+++ b/tests/ladderTest/test_csv_to_sqlite.py
@@ -64,6 +64,7 @@ def _create_sample_csv(path: Path) -> None:
 
 
 def test_csv_to_sqlite_table(tmp_path: Path) -> None:
+    """CSV rows are loaded into a SQLite table."""
     csv_file = tmp_path / "data.csv"
     db_file = tmp_path / "db.sqlite"
     _create_sample_csv(csv_file)
@@ -80,6 +81,7 @@ def test_csv_to_sqlite_table(tmp_path: Path) -> None:
 
 
 def test_get_table_schema(tmp_path: Path) -> None:
+    """Schema is returned after table creation."""
     csv_file = tmp_path / "data.csv"
     db_file = tmp_path / "db.sqlite"
     _create_sample_csv(csv_file)
@@ -94,6 +96,7 @@ def test_get_table_schema(tmp_path: Path) -> None:
 
 
 def test_query_sqlite_table(tmp_path: Path) -> None:
+    """Querying the table returns expected rows."""
     csv_file = tmp_path / "data.csv"
     db_file = tmp_path / "db.sqlite"
     _create_sample_csv(csv_file)

--- a/tests/ttapi/test_tt_utils.py
+++ b/tests/ttapi/test_tt_utils.py
@@ -1,5 +1,3 @@
-import re
-
 from TTRestAPI.tt_utils import (
     create_request_id,
     generate_guid,
@@ -9,11 +7,13 @@ from TTRestAPI.tt_utils import (
 
 
 def test_generate_guid_is_valid() -> None:
+    """Generated GUIDs pass the validator."""
     guid = generate_guid()
     assert is_valid_guid(guid)
 
 
 def test_create_request_id_format() -> None:
+    """Request IDs combine sanitized prefix with GUID."""
     req_id = create_request_id("My App", "Acme Co")
     prefix, guid = req_id.split("--")
     assert prefix == "My_App-Acme_Co"
@@ -21,6 +21,7 @@ def test_create_request_id_format() -> None:
 
 
 def test_sanitize_request_id_part() -> None:
+    """sanitize_request_id_part strips invalid characters."""
     text = "My @App/Name"
     sanitized = sanitize_request_id_part(text)
     assert sanitized == "My_AppName"

--- a/tests/utils/test_colour_palette.py
+++ b/tests/utils/test_colour_palette.py
@@ -1,8 +1,8 @@
 from dataclasses import FrozenInstanceError
 
-import pytest  # type: ignore[import-not-found]
+import pytest
 
-from utils.colour_palette import (  # type: ignore[import-not-found]
+from utils.colour_palette import (
     default_theme,
     get_button_default_style,
     get_combobox_default_style,
@@ -19,6 +19,7 @@ from utils.colour_palette import (  # type: ignore[import-not-found]
 
 
 def test_default_theme_values() -> None:
+    """Ensure default theme constants are as expected."""
     assert default_theme.base_bg == "#000000"
     assert default_theme.panel_bg == "#121212"
     assert default_theme.primary == "#18F0C3"
@@ -31,67 +32,79 @@ def test_default_theme_values() -> None:
 
 
 def test_theme_is_frozen() -> None:
+    """Default theme dataclass should be immutable."""
     with pytest.raises(FrozenInstanceError):
         default_theme.base_bg = "#FFF"
 
 
 def test_get_combobox_default_style() -> None:
+    """ComboBox default style matches theme colors."""
     style = get_combobox_default_style(default_theme)
     assert style["backgroundColor"] == default_theme.panel_bg
     assert style["color"] == default_theme.text_light
 
 
 def test_get_button_default_style() -> None:
+    """Button style uses primary color and light text."""
     style = get_button_default_style(default_theme)
     assert style["backgroundColor"] == default_theme.primary
     assert style["color"] == default_theme.text_light
 
 
 def test_get_container_default_style() -> None:
+    """Container defaults include panel background and border radius."""
     style = get_container_default_style(default_theme)
     assert style["backgroundColor"] == default_theme.panel_bg
     assert "borderRadius" in style
 
 
 def test_get_datatable_default_styles() -> None:
+    """DataTable styles derive from the theme palette."""
     styles = get_datatable_default_styles(default_theme)
     assert styles["style_header"]["backgroundColor"] == default_theme.panel_bg
     assert styles["style_cell"]["backgroundColor"] == default_theme.base_bg
 
 
 def test_get_graph_figure_layout_defaults() -> None:
+    """Graph figure layout uses theme colors."""
     layout = get_graph_figure_layout_defaults(default_theme)
     assert layout["plot_bgcolor"] == default_theme.base_bg
     assert layout["paper_bgcolor"] == default_theme.panel_bg
 
 
 def test_get_graph_wrapper_default_style() -> None:
+    """Graph wrapper returns empty style by default."""
     assert get_graph_wrapper_default_style(default_theme) == {}
 
 
 def test_get_grid_default_style() -> None:
+    """Grid default style uses panel background."""
     style = get_grid_default_style(default_theme)
     assert style["backgroundColor"] == default_theme.panel_bg
 
 
 def test_get_listbox_default_styles() -> None:
+    """ListBox styles include scroll area and colors."""
     styles = get_listbox_default_styles(default_theme, height_px=100)
     assert styles["style"]["backgroundColor"] == default_theme.panel_bg
 
 
 def test_get_radiobutton_default_styles() -> None:
+    """RadioButton styles honor theme and checked color."""
     styles = get_radiobutton_default_styles(default_theme)
     assert styles["style"]["color"] == default_theme.text_light
     assert styles["input_checked_style"]["backgroundColor"] == default_theme.primary
 
 
 def test_get_tabs_default_styles() -> None:
+    """Tabs style uses theme colors for active and inactive labels."""
     styles = get_tabs_default_styles(default_theme)
     assert styles["main_tabs_style"]["borderBottom"].endswith(default_theme.primary)
     assert styles["label_style"]["color"] == default_theme.text_subtle
 
 
 def test_get_mermaid_default_styles() -> None:
+    """Mermaid styling merges theme variables."""
     styles = get_mermaid_default_styles(default_theme)
     assert styles["style"]["backgroundColor"] == default_theme.panel_bg
     assert styles["mermaid_config"]["themeVariables"]["primaryColor"] == default_theme.primary


### PR DESCRIPTION
## Summary
- add Google-style docstrings to all test functions
- document this improvement in progress notes

## Testing
- `ruff check tests/...`
- `mypy --strict --ignore-missing-imports --follow-imports skip tests/...` *(fails: unused ignore comments, etc.)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'chromedriver_binary')*